### PR TITLE
Use 2020.5 as an image tag instead of latest

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -6,7 +6,7 @@ octopus:
     annotations: {}
     labels: {}
   # The Octopus server image. Visit https://hub.docker.com/r/octopusdeploy/octopusdeploy for the available versions.
-  image: octopusdeploy/octopusdeploy:latest
+  image: octopusdeploy/octopusdeploy:2020.5
   # Set this to 1 if you do not have a HA license.
   replicaCount: 1
   # The Octopus admin username


### PR DESCRIPTION
Using `latest` could bring unexpected breaking changes. Change it to the one matches `appVersion` 